### PR TITLE
Improve solver speed and convection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ After deployment you will receive a web app URL. Visiting that URL loads `index.
 1. Enter the heat source length and width.
 2. Add material layers in the table.
 3. Click **Run** to calculate thermal resistance.
+4. When using convection mode you may optionally provide a `shapeFactor` or an `hMap` array to model non-uniform cooling.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- use adaptive step sizing for layer solving
- precompute cone-spread ratios
- allow convection calculations to use shape factors or h-map input
- document optional convection inputs

## Testing
- `node - <<'EOF'
const fs=require('fs');
try{ new Function(fs.readFileSync('Code.gs','utf8')); console.log('Syntax OK'); }catch(e){ console.error('syntax error',e); process.exit(1);}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_683f731356ac83248f00495338fcddd2