### PR TITLE
Improve summary and export options

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -167,7 +167,8 @@ function solve(p) {
     rDie,       // Total R_th per die (stack + cooler)
     rTotal,     // Overall R_th for all dies combined
     numDies: p.dies, // Pass number of dies to client
-    rCoolPerDie: rCool // ADDED: Pass per-die cooler resistance to client
+    rCoolPerDie: rCool, // ADDED: Pass per-die cooler resistance to client
+    rStack      // Send cumulative stack Rth back for percentage calculations
   };
 }
 

--- a/index.html
+++ b/index.html
@@ -44,9 +44,10 @@
 
       <div class="sumBox flexInner"><!-- summary table + curve -->
         <table id="sumTbl">
-          <thead><tr><th>Layer</th><th>Rth (total stack) [°C/W]</th><th>Cumulative Rth (total stack) [°C/W]</th><th>Length (Y) at bottom [mm]</th></tr></thead>
+          <thead><tr><th>Layer</th><th>Rth (total stack) [°C/W]</th><th>Cumulative Rth (total stack) [°C/W]</th><th>Length (Y) at bottom [mm]</th><th>Contribution [%]</th><th>Sensitivity [%]</th></tr></thead>
           <tbody></tbody>
         </table>
+        <button id="btnExport" style="margin-top:6px">Export CSV</button>
         <svg id="cumSvg"></svg>
       </div>
     </div>

--- a/styles.html
+++ b/styles.html
@@ -19,4 +19,5 @@
   .coneBox{flex:0 0 340px;max-height:200px;overflow:hidden;}
   .sumBox{min-width:240px;} .sumBox.flexInner{display:flex;gap:10px;align-items:flex-start;}
   #cumSvg{width:260px;height:auto;overflow:visible;}
+  .critical{background:#523131;}
 </style>

--- a/ui.html
+++ b/ui.html
@@ -12,6 +12,7 @@ const tbl = $('layerTbl'), btnAdd = $('btnAdd'), btnRun = $('btnCalc'); //
 const outDie = $('outDie'), outTot = $('outTotal'); //
 const cone = $('cone'), sumBody = $('sumTbl').tBodies[0], cumSvg = $('cumSvg'); //
 const resultCard = $('resultCard'); //
+const btnExport = $('btnExport'); //
 
 // Handles for elements in controls.html
 const srcLen = $('srcLen'), srcWid = $('srcWid'), dies = $('dies'); //
@@ -100,8 +101,8 @@ function draw(o) {
   
   buildCone(o.widths); //
   
-  // MODIFICATION: Pass o.rCoolPerDie and o.rTotal to buildSummary
-  buildSummary(o.rEach, o.rCum, o.lengths, o.numDies, o.rCoolPerDie, o.rTotal);
+  // MODIFICATION: Pass o.rCoolPerDie, o.rTotal and o.rStack to buildSummary
+  buildSummary(o.rEach, o.rCum, o.lengths, o.numDies, o.rCoolPerDie, o.rTotal, o.rStack);
 
   if (resultCard) { //
     resultCard.style.display = '';  //
@@ -162,7 +163,7 @@ function buildCone(widths) { //
 
 /* ======================= Summary table + curve ======================= */
 // MODIFICATION: Updated signature and logic for buildSummary
-function buildSummary(rEach, rCumulative, lengthsFromServer, numDies, rCoolPerDie, rTotalForCoolerCum) {
+function buildSummary(rEach, rCumulative, lengthsFromServer, numDies, rCoolPerDie, rTotalForCoolerCum, rStack) {
   sumBody.innerHTML = '';  //
   // Check if essential layer data arrays are consistent if layers exist
   if (rEach && rCumulative && lengthsFromServer && rEach.length > 0 && 
@@ -184,6 +185,8 @@ function buildSummary(rEach, rCumulative, lengthsFromServer, numDies, rCoolPerDi
   }
 
   const cumulativeRthForTotalStackGraph = []; // For the graph (layers only)
+  let highestIdx = -1; // track highest resistance layer
+  let highestVal = -Infinity;
 
   if (rEach && rEach.length > 0) { // Only iterate if there are layers and rEach is defined
     rEach.forEach((val, i) => { //
@@ -208,8 +211,24 @@ function buildSummary(rEach, rCumulative, lengthsFromServer, numDies, rCoolPerDi
       const rEachText = (typeof rEachLayerForTotalStack === 'number' && isFinite(rEachLayerForTotalStack)) ? rEachLayerForTotalStack.toFixed(4) : (rEachLayerForTotalStack === Infinity ? "Infinity" : "-"); //
       const rCumText = (typeof rCumLayerForTotalStack === 'number' && isFinite(rCumLayerForTotalStack)) ? rCumLayerForTotalStack.toFixed(4) : (rCumLayerForTotalStack === Infinity ? "Infinity" : "-"); //
 
-      row.innerHTML = `<td>L${i + 1}</td><td>${rEachText}</td><td>${rCumText}</td><td>${lengthAtBottom_mm_text}</td>`; //
+      let contrib = '-';
+      let sensText = '-';
+      if (typeof rStack === 'number' && isFinite(rStack) && rStack > 0 && typeof val === 'number' && isFinite(val)) {
+        const perc = (val / rStack) * 100;
+        contrib = perc.toFixed(1);
+        sensText = perc.toFixed(1);
+      }
+
+      if (typeof val === 'number' && isFinite(val) && val > highestVal) {
+        highestVal = val;
+        highestIdx = i;
+      }
+
+      row.innerHTML = `<td>L${i + 1}</td><td>${rEachText}</td><td>${rCumText}</td><td>${lengthAtBottom_mm_text}</td><td>${contrib}</td><td>${sensText}</td>`; //
     });
+    if (highestIdx >= 0 && sumBody.rows[highestIdx]) {
+      sumBody.rows[highestIdx].classList.add('critical');
+    }
   }
 
   // Add Cooler Row
@@ -219,7 +238,7 @@ function buildSummary(rEach, rCumulative, lengthsFromServer, numDies, rCoolPerDi
   const coolerRthText = (typeof coolerRthValTotalStack === 'number' && isFinite(coolerRthValTotalStack)) ? coolerRthValTotalStack.toFixed(4) : (coolerRthValTotalStack === Infinity ? "Infinity" : "-");
   const coolerCumRthText = (typeof rTotalForCoolerCum === 'number' && isFinite(rTotalForCoolerCum)) ? rTotalForCoolerCum.toFixed(4) : (rTotalForCoolerCum === Infinity ? "Infinity" : "-");
   
-  coolerRow.innerHTML = `<td>Cooler</td><td>${coolerRthText}</td><td>${coolerCumRthText}</td><td>-</td>`;
+  coolerRow.innerHTML = `<td>Cooler</td><td>${coolerRthText}</td><td>${coolerCumRthText}</td><td>-</td><td>-</td><td>-</td>`;
 
   // Graphing logic remains for layers only
   const finiteCumulativeRthForGraph = cumulativeRthForTotalStackGraph.filter(val => typeof val === 'number' && isFinite(val)); //
@@ -316,10 +335,27 @@ function NS(tag, attrs) { //
   return el; //
 }
 
+/* ======================= Export results ======================= */
+function exportResults() { //
+  const table = $('sumTbl'); //
+  if (!table) return; //
+  const rows = [...table.rows]; //
+  const csv = rows.map(r => [...r.cells].map(c => '"' + c.textContent + '"').join(',')).join('\n'); //
+  const blob = new Blob([csv], {type: 'text/csv'}); //
+  const url = URL.createObjectURL(blob); //
+  const a = document.createElement('a'); //
+  a.href = url; //
+  a.download = 'rth_results.csv'; //
+  document.body.appendChild(a); //
+  a.click(); //
+  setTimeout(() => { URL.revokeObjectURL(url); a.remove(); }, 0); //
+}
+
 /* ======================= Initial setup ======================= */
 document.addEventListener('DOMContentLoaded', () => { //
   if (btnAdd) btnAdd.onclick = () => addRow(); //
   if (btnRun) btnRun.onclick = runCalc; //
+  if (btnExport) btnExport.onclick = exportResults; //
   if (coolSel) coolSel.onchange = updateCoolerVisibility; //
 
   if (srcLen) srcLen.value = '5'; //


### PR DESCRIPTION
## Summary
- expose `rStack` from the solver for percent calculations
- show layer contributions and sensitivity in results table
- highlight the critical (highest-R) layer
- allow exporting the summary as CSV

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f80108aa08324ad9c24468c57f6e5