### PR TITLE
Add JSON import/export

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -316,6 +316,22 @@ function optimizeLayers(p) {
   return { recommendations: recs, rDie: bestR };
 }
 
+/* ==================== Stack persistence ==================== */
+function setStack(stack) {
+  try {
+    const json = typeof stack === 'string' ? stack : JSON.stringify(stack);
+    PropertiesService.getUserProperties().setProperty('stackPayload', json);
+    return true;
+  } catch (e) {
+    throw new Error('Failed to store stack: ' + e.message);
+  }
+}
+
+function getStack() {
+  const json = PropertiesService.getUserProperties().getProperty('stackPayload');
+  return json ? JSON.parse(json) : null;
+}
+
 /* ====================================================================================================
    UI bootstrap helpers (doGet, inc) - These functions remain unchanged.
    ==================================================================================================== */

--- a/index.html
+++ b/index.html
@@ -50,6 +50,8 @@
           <tbody></tbody>
         </table>
         <button id="btnExport" style="margin-top:6px">Export CSV</button>
+        <button id="btnSaveStack" style="margin-top:6px;margin-left:6px">Save JSON</button>
+        <button id="btnLoadStack" style="margin-top:6px;margin-left:6px">Load JSON</button>
         <svg id="cumSvg"></svg>
       </div>
     </div>

--- a/ui.html
+++ b/ui.html
@@ -13,6 +13,8 @@ const outDie = $('outDie'), outTot = $('outTotal'); //
 const cone = $('cone'), sumBody = $('sumTbl').tBodies[0], cumSvg = $('cumSvg'); //
 const resultCard = $('resultCard'); //
 const btnExport = $('btnExport'); //
+const btnSaveStack = $('btnSaveStack'); //
+const btnLoadStack = $('btnLoadStack'); //
 const btnMonte = $('btnMonte'); //
 const btnOptimize = $('btnOptimize'); //
 const mcIter = $('mcIter'), mcUncT = $('mcUncT'), mcUncK = $('mcUncK'); //
@@ -502,6 +504,57 @@ function exportResults() { //
   setTimeout(() => { URL.revokeObjectURL(url); a.remove(); }, 0); //
 }
 
+/* ======================= Save / Load JSON ======================= */
+function saveStack() { //
+  const rows = [...tbl.tBodies[0].rows]; //
+  if (!rows.length) { //
+    alert('Add a layer first'); //
+    return; //
+  }
+  const layers = rows.map(r => ({ //
+    mat: r.cells[1].firstElementChild.value, //
+    t:   +r.cells[2].firstElementChild.value, //
+    kx:  +r.cells[3].firstElementChild.value, //
+    ky:  +r.cells[4].firstElementChild.value, //
+    kz:  +r.cells[5].firstElementChild.value //
+  }));
+  const payload = { //
+    srcLen: +srcLen.value, //
+    srcWid: +srcWid.value, //
+    dies:   +dies.value, //
+    coolerMode: coolSel.value, //
+    coolerRth:  +coolRth.value, //
+    hConv:      +hConv.value, //
+    layers //
+  };
+
+  google.script.run
+    .withSuccessHandler(() => alert('Stack saved'))
+    .withFailureHandler(err => { alert('Save failed: ' + err.message); console.error(err); })
+    .setStack(payload);
+}
+
+function loadStack() { //
+  google.script.run
+    .withSuccessHandler(data => { //
+      if (!data) { //
+        alert('No saved stack'); //
+        return; //
+      }
+      srcLen.value = data.srcLen; //
+      srcWid.value = data.srcWid; //
+      dies.value = data.dies; //
+      coolSel.value = data.coolerMode; //
+      updateCoolerVisibility(); //
+      coolRth.value = data.coolerRth; //
+      hConv.value = data.hConv; //
+      tbl.tBodies[0].innerHTML = ''; //
+      if (Array.isArray(data.layers)) data.layers.forEach(l => addRow(l)); //
+    })
+    .withFailureHandler(err => { alert('Load failed: ' + err.message); console.error(err); })
+    .getStack();
+}
+
 /* ======================= Initial setup ======================= */
 document.addEventListener('DOMContentLoaded', () => { //
   if (btnAdd) btnAdd.onclick = () => addRow(); //
@@ -509,6 +562,8 @@ document.addEventListener('DOMContentLoaded', () => { //
   if (btnMonte) btnMonte.onclick = runMonte; //
   if (btnOptimize) btnOptimize.onclick = runOptimization; //
   if (btnExport) btnExport.onclick = exportResults; //
+  if (btnSaveStack) btnSaveStack.onclick = saveStack; //
+  if (btnLoadStack) btnLoadStack.onclick = loadStack; //
   if (coolSel) coolSel.onchange = updateCoolerVisibility; //
 
   if (srcLen) srcLen.value = '5'; //


### PR DESCRIPTION
## Summary
- support saving and loading the whole stack as JSON
- add two new buttons to save or load the JSON state
- wire up save/load handlers in `ui.html`
- store stack JSON in `UserProperties`

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68400a91f7c483249c9cb11b582894c2