### PR TITLE
Improve visualization layout and coordinate generation

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -146,24 +146,32 @@ function solveSingleDieStack(p1) {
 function getCoords(layout, n, spacing, custom) {
   const arr = [];
   const s = typeof spacing === 'number' ? spacing : 0;
-  if (layout === 'square' && n >= 4) {
+  if (layout === 'square' && n >= 1) {
     const d = s / 2;
-    arr.push([-d,-d],[d,-d],[-d,d],[d,d]);
-    for (let i=4;i<n;i++) arr.push([0,0]);
-  } else if (layout === 'diamond' && n >= 4) {
+    arr.push([-d, -d]);
+    if (n >= 2) arr.push([d, -d]);
+    if (n >= 3) arr.push([-d, d]);
+    if (n >= 4) arr.push([d, d]);
+    // For dies 5 and up, place them linearly
+    for (let i = 4; i < n; i++) arr.push([(i - 1.5) * s, 0]);
+  } else if (layout === 'diamond' && n >= 1) {
     const d = s / 2;
-    arr.push([0,-d],[-d,0],[0,d],[d,0]);
-    for (let i=4;i<n;i++) arr.push([0,0]);
+    arr.push([0, -d]);
+    if (n >= 2) arr.push([-d, 0]);
+    if (n >= 3) arr.push([0, d]);
+    if (n >= 4) arr.push([d, 0]);
+    // For dies 5 and up, place them linearly
+    for (let i = 4; i < n; i++) arr.push([(i - 1.5) * s, 0]);
   } else if (layout === 'custom' && typeof custom === 'string') {
-    custom.split(';').forEach(p=>{
+    custom.split(';').forEach(p => {
       const parts = p.split(',');
-      if (parts.length===2) arr.push([parseFloat(parts[0])||0, parseFloat(parts[1])||0]);
+      if (parts.length === 2) arr.push([parseFloat(parts[0]) || 0, parseFloat(parts[1]) || 0]);
     });
-    while (arr.length < n) arr.push([0,0]);
-  } else {
-    for (let i=0;i<n;i++) arr.push([i*s,0]);
+    while (arr.length < n) arr.push([0, 0]);
+  } else { // Default to 'line' layout
+    for (let i = 0; i < n; i++) arr.push([i * s, 0]);
   }
-  return arr.slice(0,n);
+  return arr.slice(0, n);
 }
 
 /** Utility to compute distance between two coords in metres. */

--- a/index.html
+++ b/index.html
@@ -50,11 +50,17 @@
     <p id="outDie">Rth / die = – °C/W</p>
     <p id="outTotal" class="small">Total stack (all dies) = – °C/W</p>
 
+    <!-- NEW DEDICATED VISUALIZATION SECTION -->
+    <section class="card viz-container">
+        <h2>Results Visualizations</h2>
+        <div class="flexBox">
+            <div id="cone" class="coneBox" title="Side-view of heat spreading through the stack"></div>
+            <div id="layoutView" class="coneBox" title="Top-down view of die layout and final footprints"></div>
+        </div>
+    </section>
+
+    <!-- ORIGINAL SUMMARY SECTION -->
     <div class="flexBox">
-      <div id="cone" class="coneBox" title="2‑D view of heat spreading through the stack"></div><!-- 2‑D cone -->
-
-      <div id="layoutView" class="coneBox" title="Top-down view of die layout and final footprints"></div>
-
       <div class="sumBox flexInner"><!-- summary table + curve -->
         <table id="sumTbl" title="Thermal resistance summary by layer">
           <thead>

--- a/styles.html
+++ b/styles.html
@@ -13,10 +13,13 @@
   button{border:none;border-radius:4px;padding:6px 12px;cursor:pointer;background:#007acc;color:#fff;font-weight:600;margin-top:8px;} button.primary{font-size:16px;padding:8px 18px} button:hover{background:#1497ff}
 
   .hide{display:none;} .small{color:#006bb3;font-size:13px} .result p{margin:4px 0}
+  .viz-container {
+    padding-bottom: 20px;
+  }
 
   /* —— layout for cone + summary —— */
   .flexBox{display:flex;gap:18px;align-items:flex-start;}
-  .coneBox{flex: 1;max-height:200px;overflow:hidden;}
+  .coneBox{flex: 1; min-width: 250px; height: 200px; overflow:hidden;}
   .sumBox{min-width:240px;} .sumBox.flexInner{display:flex;gap:10px;align-items:flex-start;}
   #cumSvg{width:260px;height:auto;overflow:visible;}
   #histSvg{width:260px;height:auto;overflow:visible;}


### PR DESCRIPTION
## Summary
- create dedicated visualization section on results card
- expand coordinate layout logic for square and diamond
- tweak layout CSS and add viz-container rule

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842c5b31fe08324b208949c8f233a32