### PR TITLE
Improve results layout with top-down view

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,12 +52,22 @@
 
     <!-- NEW DEDICATED VISUALIZATION SECTION -->
     <section class="card viz-container">
-        <h2>Results Visualizations</h2>
-        <div class="flexBox">
-            <div id="sideViewX" class="coneBox" title="Side-view of heat spreading (X-Z plane)"></div>
-            <div id="sideViewY" class="coneBox" title="Side-view of heat spreading (Y-Z plane)"></div>
+      <h2>Results Visualizations</h2>
+      <div class="flexBox">
+        <!-- Left Column for Side Views -->
+        <div class="viz-column-left">
+          <h3>X axis Thermal dissipation</h3>
+          <div id="sideViewX" class="side-view-box"></div>
+          <h3>Y axis Thermal dissipation</h3>
+          <div id="sideViewY" class="side-view-box"></div>
         </div>
-      </section>
+        <!-- Right Column for Top View -->
+        <div class="viz-column-right">
+          <h3>Top view layout:</h3>
+          <div id="layoutView" class="top-view-box"></div>
+        </div>
+      </div>
+    </section>
 
     <!-- ORIGINAL SUMMARY SECTION -->
     <div class="flexBox">

--- a/styles.html
+++ b/styles.html
@@ -19,7 +19,7 @@
 
   /* —— layout for cone + summary —— */
   .flexBox{display:flex;gap:18px;align-items:flex-start;}
-  .coneBox{flex: 1; min-width: 250px; height: 200px; overflow:hidden;}
+  .side-view-box { height: 150px; border: 1px solid #ccc; border-radius: 4px; overflow: hidden; }
   .sumBox{
     display:flex;
     flex-direction:column;
@@ -29,6 +29,36 @@
   #cumSvg{width:100%;height:180px;overflow:visible;}
   #histSvg{width:260px;height:auto;overflow:visible;}
   .critical{background:#f8d7da;}
+
+  .viz-column-left {
+    flex: 2; /* Takes up 2/3 of the space */
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+  }
+  .viz-column-right {
+    flex: 1; /* Takes up 1/3 of the space */
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+  }
+  .top-view-box {
+    height: 318px; /* Match height of the two side views + gap */
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  .viz-container h3 {
+    margin: 0 0 5px 0;
+    font-size: 15px;
+    color: #005a99;
+  }
+  body.dark-theme .viz-container h3 {
+    color: #82c6ff;
+  }
+  body.dark-theme .side-view-box, body.dark-theme .top-view-box {
+    border-color: #324357;
+  }
 
   /* ===== dark theme overrides ===== */
   body.dark-theme{background:#0E1A25;color:#E8EEF2;}

--- a/ui.html
+++ b/ui.html
@@ -10,7 +10,7 @@ const $ = id => document.getElementById(id); //
 // Handles for elements in index.html
 const tbl = $('layerTbl'), btnAdd = $('btnAdd'), btnRun = $('btnCalc'); //
 const outDie = $('outDie'), outTot = $('outTotal'); //
-const sideViewX = $('sideViewX'), sideViewY = $('sideViewY');
+const sideViewX = $('sideViewX'), sideViewY = $('sideViewY'), layoutView = $('layoutView');
 const sumBody = $('sumTbl').tBodies[0], cumSvg = $('cumSvg');
 const resultCard = $('resultCard'); //
 const btnMonte = $('btnMonte'); //
@@ -225,6 +225,7 @@ function draw(o) {
 
   buildSideView('x', sideViewX, o);
   buildSideView('y', sideViewY, o);
+  buildLayoutView(o);
 
   // MODIFICATION: Pass sensitivity data along with cooler info
   buildSummary(o.rEach, o.rCum, o.lengths, o.numDies, o.rCoolPerDie, o.rTotal, o.rStack, o.sensitivity);
@@ -615,12 +616,11 @@ function buildLayoutView(o) {
     maxY = Math.max(maxY, fp.cy + fp.l / 2);
   });
 
-  const paddingX = (maxX - minX) * 0.1 || 1;
-  const paddingY = (maxY - minY) * 0.1 || 1;
-  minX -= paddingX;
-  maxX += paddingX;
-  minY -= paddingY;
-  maxY += paddingY;
+  const padding = Math.max(initialW, initialL) * 0.5;
+  minX -= padding;
+  maxX += padding;
+  minY -= padding;
+  maxY += padding;
 
   const viewW = maxX - minX;
   const viewH = maxY - minY;


### PR DESCRIPTION
## Summary
- show thermal results using three panels
- style new layout columns and add dark theme rules
- revive top view layout generation in the UI

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842f6c8c484832483db2b8b8d75c16e