### PR TITLE
Add material tooltips for side view

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -429,6 +429,7 @@ function coreSolve(p) {
   const rTotal = P_total > 0 ? sys.maxTemp / P_total : 0;
 
   const { rEach, rCum, lengths, widths, widthsX, widthsY, rCool, rStack } = tplResult;
+  const materialNames = p.layers.map(function(L){ return typeof L.mat === 'string' ? L.mat : ''; });
 
   return {
     rEach,
@@ -437,6 +438,7 @@ function coreSolve(p) {
     lengths,
     widthsX,
     widthsY,
+    materialNames,
     coords: matrixInfo.coords,
     rDie,
     rTotal,

--- a/ui.html
+++ b/ui.html
@@ -390,10 +390,19 @@ function buildSideView(axis, container, o) {
   // --- Draw Layers and Cooler ---
   let currentY = 0;
   layers.forEach((layer, i) => {
-    svg.appendChild(NS('rect', {
-      x: sceneMin, y: currentY, width: sceneWidth, height: layer.t,
+    const rect = NS('rect', {
+      x: sceneMin,
+      y: currentY,
+      width: sceneWidth,
+      height: layer.t,
       fill: i % 2 === 0 ? '#E0E0E0' : '#CCCCCC'
-    }));
+    });
+    if (o && Array.isArray(o.materialNames) && o.materialNames[i]) {
+      const title = NS('title');
+      title.textContent = o.materialNames[i];
+      rect.appendChild(title);
+    }
+    svg.appendChild(rect);
     currentY += layer.t;
   });
   svg.appendChild(NS('rect', {


### PR DESCRIPTION
## Summary
- send `materialNames` from the backend
- show layer tooltips in the side view visualization

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684825e6a67483248e612106ab9095bf