### PR TITLE
Improve Monte Carlo controls and graph styling

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -567,7 +567,7 @@ function solveMonteCarlo(p) {
         diePower:  p.diePower,
         layers: perturbed
       });
-      results.push(r.rDie);
+      results.push(r.rTotal);
       let maxV = -Infinity, maxI = 0;
       r.rEach.forEach((val, idx) => {
         if (typeof val === 'number' && val > maxV) { maxV = val; maxI = idx; }

--- a/controls.html
+++ b/controls.html
@@ -73,15 +73,20 @@
 
 <section class="card inline">
   <h2>Monte Carlo</h2>
-  <label title="Number of random simulations to run">Iterations
-    <input id="mcIter" type="number" min="1" value="200">
+  <label>
+    <input id="mcEnable" type="checkbox"> Enable
   </label>
-  <label title="Percentage deviation applied to thickness in simulations">t&nbsp;uncertainty&nbsp;[%]
-    <input id="mcUncT" type="number" step="0.1" value="5">
-  </label>
-  <label title="Percentage deviation applied to conductivities in simulations">k&nbsp;uncertainty&nbsp;[%]
-    <input id="mcUncK" type="number" step="0.1" value="5">
-  </label>
+  <div id="mcConfig" class="hide">
+    <label title="Number of random simulations to run">Iterations
+      <input id="mcIter" type="number" min="1" value="200">
+    </label>
+    <label title="Percentage deviation applied to thickness in simulations">t&nbsp;uncertainty&nbsp;[%]
+      <input id="mcUncT" type="number" step="0.1" value="5">
+    </label>
+    <label title="Percentage deviation applied to conductivities in simulations">k&nbsp;uncertainty&nbsp;[%]
+      <input id="mcUncK" type="number" step="0.1" value="5">
+    </label>
+  </div>
 </section>
 
 <section class="card inline">

--- a/styles.html
+++ b/styles.html
@@ -24,6 +24,9 @@
   #histSvg{width:260px;height:auto;overflow:visible;}
   .critical{background:#f8d7da;}
 
+  .axis-text { fill: #111; }
+  body.dark-theme .axis-text { fill: #E8EEF2; }
+
   #crosstalkMatrixTable { width:100%; border-collapse: collapse; margin-top:8px; }
   #crosstalkMatrixTable th, #crosstalkMatrixTable td { border:1px solid #bbb; padding:3px 6px; text-align:center; }
   #crosstalkMatrixContainer { overflow-x: auto; }

--- a/ui.html
+++ b/ui.html
@@ -15,6 +15,7 @@ const sumBody = $('sumTbl').tBodies[0], cumSvg = $('cumSvg');
 const resultCard = $('resultCard'); //
 const sweepResultCard = $('sweepResultCard'), sweepChart = $('sweepChart'); //
 const btnMonte = $("btnMonte"), btnSweep = $("btnSweep"), btnSave = $("btnSave"), btnLoad = $("btnLoad"); //
+const mcEnable = $('mcEnable'), mcConfig = $('mcConfig'); //
 const mcIter = $('mcIter'), mcUncT = $('mcUncT'), mcUncK = $('mcUncK'); //
 const mcCard = $('mcResult'), mcStats = $('mcStats'), histSvg = $('histSvg'); //
 const btnReadme = $('btnReadme'), readmeDiv = $('readmeDiv'); //
@@ -73,6 +74,11 @@ function updateSweepVisibility() { //
   sweepConfig.classList.toggle('hide', !sweepEnable.checked); //
 }
 
+function updateMonteVisibility() { //
+  if (!mcEnable || !mcConfig) return; //
+  mcConfig.classList.toggle('hide', !mcEnable.checked); //
+}
+
 function toggleReadme() { //
   if (!readmeDiv) return; //
   const isHidden = readmeDiv.style.display === 'none' || readmeDiv.style.display === ''; //
@@ -105,6 +111,7 @@ function saveStack() {
     coolerRth: +coolRth.value,
     hConv: +hConv.value,
     coolTemp: +coolTemp.value,
+    mcEnable: mcEnable ? mcEnable.checked : false,
     mcIter: +mcIter.value,
     mcUncT: +mcUncT.value,
     mcUncK: +mcUncK.value,
@@ -136,8 +143,8 @@ function loadStack() {
     srcWid.value = data.srcWid || 5;
     dies.value = data.dies || 4;
     diePower.value = data.diePower || 1.0;
-    dieSpacingX.value = data.spacingX || 1;
-    dieSpacingY.value = data.spacingY || 1;
+    dieSpacingX.value = data.spacingX || 10;
+    dieSpacingY.value = data.spacingY || 10;
     dieLayout.value = data.layout || 'line';
     customCoords.value = data.coords || '';
 
@@ -146,6 +153,8 @@ function loadStack() {
     hConv.value = data.hConv || 38500;
     coolTemp.value = data.coolTemp || 55;
     
+    if (mcEnable) mcEnable.checked = !!data.mcEnable;
+    updateMonteVisibility();
     mcIter.value = data.mcIter || 200;
     mcUncT.value = data.mcUncT || 5;
     mcUncK.value = data.mcUncK || 5;
@@ -242,6 +251,10 @@ function runCalc() { //
 }
 
 function runMonte() { //
+  if (!mcEnable || !mcEnable.checked) { //
+    alert('Enable Monte Carlo first.'); //
+    return; //
+  }
   const rows = [...tbl.tBodies[0].rows]; //
   if (!rows.length) { //
     alert('Add a layer first'); //
@@ -403,7 +416,7 @@ function drawMonte(o) {
     alert('Failed Monte Carlo calculation.');
     return;
   }
-  mcStats.textContent = `n=${o.iterations}, mean=${o.mean.toFixed(3)}\u00A0\xB0C/W, \u03C3=${o.stdev.toFixed(3)}`;
+  mcStats.textContent = `n=${o.iterations}, mean=${o.mean.toFixed(3)}\u00A0\xB0C/W, \u03C3=${o.stdev.toFixed(3)} (total stack)`;
   buildHistogram(o.results);
   if (o.critical && Array.isArray(o.critical) && o.critical.length > 0) {
     const idx = o.critical.indexOf(Math.max(...o.critical));
@@ -565,7 +578,7 @@ function buildSummary(rEach, rCumulative, lengthsFromServer, numDies, rCoolPerDi
       if (lengthsFromServer && lengthsFromServer.length > i + 1) {  //
           const lengthAtBottom_m = lengthsFromServer[i+1]; //
           if (typeof lengthAtBottom_m === 'number' && isFinite(lengthAtBottom_m)) { //
-              lengthAtBottom_mm_text = (lengthAtBottom_m * 1000).toFixed(3); //
+              lengthAtBottom_mm_text = (lengthAtBottom_m * 1000).toFixed(2); //
           }
       }
       
@@ -666,7 +679,7 @@ function buildCurve(cumulativeRth) { //
       const tickValue = (maxRthValue * t) / numYTicks; //
       const y = yPos(tickValue); //
       cumSvg.appendChild(NS('line', { x1: margin.left - 4, y1: y, x2: margin.left, y2: y, stroke: '#888' })); //
-      const yText = NS('text', { x: margin.left - 7, y: y + 4, 'text-anchor': 'end', fill: '#9ED1F5', 'font-size': '12px' }); //
+      const yText = NS('text', { x: margin.left - 7, y: y + 4, 'text-anchor': 'end', 'class': 'axis-text', 'font-size': '12px' }); //
       yText.appendChild(document.createTextNode(tickValue.toFixed(2))); //
       cumSvg.appendChild(yText); //
     }
@@ -675,7 +688,7 @@ function buildCurve(cumulativeRth) { //
   for (let i = 0; i < numLayers; i++) { //
     const x = xPos(i); //
     cumSvg.appendChild(NS('line', { x1: x, y1: H_svg - margin.bottom, x2: x, y2: H_svg - margin.bottom + 4, stroke: '#888' })); //
-    const xText = NS('text', { x: x, y: H_svg - margin.bottom + 16, 'text-anchor': 'middle', fill: '#9ED1F5', 'font-size': '12px' }); //
+    const xText = NS('text', { x: x, y: H_svg - margin.bottom + 16, 'text-anchor': 'middle', 'class': 'axis-text', 'font-size': '12px' }); //
     xText.appendChild(document.createTextNode(`L${i + 1}`)); //
     cumSvg.appendChild(xText); //
   }
@@ -683,14 +696,14 @@ function buildCurve(cumulativeRth) { //
   const yAxisTitle = NS('text', { //
     x: margin.left - 35, y: margin.top + plotH / 2, //
     transform: `rotate(-90 ${margin.left - 35} ${margin.top + plotH / 2})`, //
-    fill: '#9ED1F5', 'font-size': '13px', 'text-anchor': 'middle' //
+    'class': 'axis-text', 'font-size': '13px', 'text-anchor': 'middle' //
   });
   yAxisTitle.appendChild(document.createTextNode('Cum. Rth (°C/W)')); //
   cumSvg.appendChild(yAxisTitle); //
 
   const xAxisTitle = NS('text', { //
     x: margin.left + plotW / 2, y: H_svg - 5, //
-    fill: '#9ED1F5', 'font-size': '13px', 'text-anchor': 'middle' //
+    'class': 'axis-text', 'font-size': '13px', 'text-anchor': 'middle' //
   });
   xAxisTitle.appendChild(document.createTextNode('Layer')); //
   cumSvg.appendChild(xAxisTitle); //
@@ -760,11 +773,11 @@ function drawSweepChart(data) {
 
   const xTitle = sweepParam ? sweepParam.options[sweepParam.selectedIndex].text : '';
   const layerNum = sweepLayer ? sweepLayer.value : '1';
-  const xAxisTitle = NS('text', { x: margin.left + plotW/2, y: H - 5, 'text-anchor': 'middle', fill:'#9ED1F5' });
+  const xAxisTitle = NS('text', { x: margin.left + plotW/2, y: H - 5, 'text-anchor': 'middle', 'class':'axis-text' });
   xAxisTitle.textContent = `Layer ${layerNum} ${xTitle}`;
   sweepChart.appendChild(xAxisTitle);
 
-  const yAxisTitle = NS('text', { x: 15, y: margin.top + plotH/2, transform:`rotate(-90 15 ${margin.top + plotH/2})`, 'text-anchor':'middle', fill:'#9ED1F5' });
+  const yAxisTitle = NS('text', { x: 15, y: margin.top + plotH/2, transform:`rotate(-90 15 ${margin.top + plotH/2})`, 'text-anchor':'middle', 'class':'axis-text' });
   yAxisTitle.textContent = 'Rth (total stack) °C/W';
   sweepChart.appendChild(yAxisTitle);
 
@@ -772,7 +785,7 @@ function drawSweepChart(data) {
     const tx = xPos(d.sweptValue);
     const ty = yPos(d.resultValue);
     sweepChart.appendChild(NS('circle', { cx: tx, cy: ty, r: 3, fill: '#ff5722' }));
-    const lbl = NS('text', { x: tx, y: ty - 6, 'text-anchor':'middle', fill:'#9ED1F5', 'font-size':'11px' });
+    const lbl = NS('text', { x: tx, y: ty - 6, 'text-anchor':'middle', 'class':'axis-text', 'font-size':'11px' });
     lbl.textContent = d.resultValue.toFixed(2);
     sweepChart.appendChild(lbl);
   });
@@ -927,6 +940,7 @@ document.addEventListener('DOMContentLoaded', () => { //
   if (coolSel) coolSel.onchange = updateCoolerVisibility;
   if (dieLayout) dieLayout.onchange = updateLayoutVisibility;
   if (sweepEnable) sweepEnable.onchange = updateSweepVisibility;
+  if (mcEnable) mcEnable.onchange = updateMonteVisibility;
 
   // Attempt to load from localStorage first
   const savedData = localStorage.getItem('rthStackV3');
@@ -947,6 +961,8 @@ document.addEventListener('DOMContentLoaded', () => { //
     if (mcIter) mcIter.value = '200';
     if (mcUncT) mcUncT.value = '5';
     if (mcUncK) mcUncK.value = '5';
+    if (mcEnable) mcEnable.checked = false;
+    updateMonteVisibility();
 
     const initialLayers = [
       { mat: "Die attach", t: 30, kxy: 198, kz: 198 },
@@ -964,6 +980,7 @@ document.addEventListener('DOMContentLoaded', () => { //
   updateCoolerVisibility();
   updateLayoutVisibility();
   updateSweepVisibility();
+  updateMonteVisibility();
   if (resultCard) resultCard.style.display = 'none';
   if (sweepResultCard) sweepResultCard.style.display = 'none';
   if (mcCard) mcCard.style.display = 'none';


### PR DESCRIPTION
## Summary
- add checkbox to enable Monte Carlo options
- store setting when saving/loading stacks
- show axis labels using standard text colour
- use total stack Rth in Monte Carlo calculations
- tweak default spacing and precision of length display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684975486e3483249cf4bc4bea5c55a2